### PR TITLE
Force WebClient to use UTF-8 Encoding

### DIFF
--- a/Source/Runtime/Client/IpcClient.cs
+++ b/Source/Runtime/Client/IpcClient.cs
@@ -30,6 +30,7 @@
         {
             using (var wc = new MyWebClient())
             {
+                wc.Encoding = Encoding.UTF8;
                 try
                 {
                     return wc.UploadString(url, @"POST", request ?? string.Empty);


### PR DESCRIPTION
The IPCServer use UTF-8 to decode the requests, so if the IPCClient sent a request with a different encoding format, the message is decoded wrong if contains special characters.